### PR TITLE
Tweak conversion mechanics to be more explicit and safe.

### DIFF
--- a/uma/currency.go
+++ b/uma/currency.go
@@ -11,7 +11,7 @@ type Currency struct {
 	Symbol string `json:"symbol"`
 
 	// MillisatoshiPerUnit is the estimated millisats per smallest "unit" of this currency (eg. 1 cent in USD).
-	MillisatoshiPerUnit int64 `json:"multiplier"`
+	MillisatoshiPerUnit float64 `json:"multiplier"`
 
 	// MinSendable is the minimum amount of the currency that can be sent in a single transaction. This is in the
 	// smallest unit of the currency (eg. cents for USD).
@@ -21,10 +21,12 @@ type Currency struct {
 	// smallest unit of the currency (eg. cents for USD).
 	MaxSendable int64 `json:"maxSendable"`
 
-	// Decimals is the number of digits after the decimal point for display on the sender side. For example,
-	// in USD, by convention, there are 2 digits for cents - $5.95. in this case, `Decimals`
-	// would be 2. Note that the multiplier is still always in the smallest unit (cents). This field
-	// is only for display purposes. The sender should assume zero if this field is omitted, unless
-	// they know the proper display format of the target currency.
-	Decimals *int `json:"decimals,omitempty"`
+	// Decimals is the number of digits after the decimal point for display on the sender side, and to add clarity
+	// around what the "smallest unit" of the currency is. For example, in USD, by convention, there are 2 digits for
+	// cents - $5.95. In this case, `decimals` would be 2. Note that the multiplier is still always in the smallest
+	// unit (cents). In addition to display purposes, this field can be used to resolve ambiguity in what the multiplier
+	// means. For example, if the currency is "BTC" and the multiplier is 1000, really we're exchanging in SATs, so
+	// `decimals` would be 8.
+	// For details on edge cases and examples, see https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md.
+	Decimals int `json:"decimals"`
 }

--- a/uma/test/uma_test.go
+++ b/uma/test/uma_test.go
@@ -117,7 +117,6 @@ func TestSignAndVerifyLnurlpResponse(t *testing.T) {
 	request := createLnurlpRequest(t, senderSigningPrivateKey.Serialize())
 	metadata, err := createMetadataForBob()
 	require.NoError(t, err)
-	dollarDisplayDecimals := 2
 	response, err := uma.GetLnurlpResponse(
 		request,
 		receiverSigningPrivateKey.Serialize(),
@@ -139,7 +138,7 @@ func TestSignAndVerifyLnurlpResponse(t *testing.T) {
 				MillisatoshiPerUnit: 34_150,
 				MinSendable:         1,
 				MaxSendable:         10_000_000,
-				Decimals:            &dollarDisplayDecimals,
+				Decimals:            2,
 			},
 		},
 		uma.KycStatusVerified,

--- a/uma/version.go
+++ b/uma/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 const MAJOR_VERSION = 0
-const MINOR_VERSION = 1
+const MINOR_VERSION = 2
 
 var UmaProtocolVersion = fmt.Sprintf("%d.%d", MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
- Make the decimals field on `Currency` required and change its description to include more details about its use.
- Change the multiplier field from int64 to float64 to allow for very small unit currencies. See https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md for details on why this is needed.

NOTE: This is technically a breaking change. Given that we're not yet at UMA 1.0, I'm bumping the protocol version here to 0.2 to indicate the bump and to be able to tell what version the counterparty is using for debugging.