### PR TITLE
Fix version future-proofing with IsUmaLnurlpQuery.

### DIFF
--- a/uma/test/uma_test.go
+++ b/uma/test/uma_test.go
@@ -86,6 +86,17 @@ func TestIsUmaQueryInvalidPath(t *testing.T) {
 	assert.False(t, uma.IsUmaLnurlpQuery(*urlObj))
 }
 
+func TestIsUmaQueryUnsupportedVersion(t *testing.T) {
+	urlString := "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=10.0&isSubjectToTravelRule=true&timestamp=12345678"
+	urlObj, _ := url.Parse(urlString)
+	assert.True(t, uma.IsUmaLnurlpQuery(*urlObj))
+
+	// Imagine if we removed the travel rule field and nonce field in a future version:
+	urlString = "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&vaspDomain=vasp1.com&umaVersion=10.0&timestamp=12345678"
+	urlObj, _ = url.Parse(urlString)
+	assert.True(t, uma.IsUmaLnurlpQuery(*urlObj))
+}
+
 func TestSignAndVerifyLnurlpRequest(t *testing.T) {
 	privateKey, err := secp256k1.GeneratePrivateKey()
 	require.NoError(t, err)

--- a/uma/uma.go
+++ b/uma/uma.go
@@ -195,6 +195,12 @@ func GetSignedLnurlpRequestUrl(
 // You should try to process the request as a regular LNURLp request to fall back to LNURL-PAY.
 func IsUmaLnurlpQuery(url url.URL) bool {
 	query, err := ParseLnurlpRequest(url)
+	// If err is an UnsupportedVersionError, the request is still an UMA request, but the version is not supported.
+	// The version negotiation should be handled by the VASP when parsing the request.
+	var unsupportedVersionError UnsupportedVersionError
+	if errors.As(err, &unsupportedVersionError) {
+		return true
+	}
 	return err == nil && query != nil
 }
 
@@ -216,6 +222,10 @@ func ParseLnurlpRequest(url url.URL) (*LnurlpRequest, error) {
 	}
 	timestampAsTime := time.Unix(timestampAsString, 0)
 
+	if umaVersion != "" && !IsVersionSupported(umaVersion) {
+		return nil, UnsupportedVersionError{}
+	}
+
 	if vaspDomain == "" || signature == "" || nonce == "" || timestamp == "" || umaVersion == "" {
 		return nil, errors.New("missing uma query parameters. vaspDomain, umaVersion, signature, nonce, and timestamp are required")
 	}
@@ -225,10 +235,6 @@ func ParseLnurlpRequest(url url.URL) (*LnurlpRequest, error) {
 		return nil, errors.New("invalid uma request path")
 	}
 	receiverAddress := pathParts[3] + "@" + url.Host
-
-	if !IsVersionSupported(umaVersion) {
-		return nil, UnsupportedVersionError{}
-	}
 
 	return &LnurlpRequest{
 		VaspDomain:            vaspDomain,


### PR DESCRIPTION
Future versions of UMA may change fields in this request, etc. so treating a parse failure as "non-uma" isn't the right behavior. We should allow the parsing to spit up the proper UnsupportedVersion exception later. This was causing the demo vasp to treat v1 requests as regular lnurl, rather than negotiating a lower UMA version.