### PR TITLE
Fix currency version serialization

### DIFF
--- a/uma/uma.go
+++ b/uma/uma.go
@@ -411,9 +411,9 @@ func GetLnurlpResponse(
 	// Ensure currencies are correctly serialized:
 	if umaVersion != nil {
 		umaVersionParsed, err := ParseVersion(*umaVersion)
-		if err != nil && umaVersionParsed != nil && umaVersionParsed.Major == 0 {
+		if err == nil && umaVersionParsed != nil {
 			for i := range *currencyOptions {
-				(*currencyOptions)[i].UmaMajorVersion = 0
+				(*currencyOptions)[i].UmaMajorVersion = umaVersionParsed.Major
 			}
 		}
 	}


### PR DESCRIPTION
0 is default int in golang so all currency is serialized to v0, instead the min(lnurlp req version, current sdk version) should be used to decide how to serialize